### PR TITLE
fix: support 3.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from calciumpy.runtime import Runtime
 
 # Calcium code is given as a JSON array.
 calcium_code = [
-  [1, [], "#", "0.4.1"],
+  [1, [], "#", "0.4.2"],
   [1, [], "expr", ["call", ["var", "print"], ["Hello, World."]]],
   [1, [], "end"],
 ]

--- a/src/calciumpy/environment.py
+++ b/src/calciumpy/environment.py
@@ -91,7 +91,7 @@ class Environment:
             return NextLineCalculation(BlockResult.SHIFT, working_line_index)
 
     def _retrieve_next_line(
-        self, working_line: int | None = None
+        self, working_line: typing.Optional[int] = None
     ) -> list[Element]:
         if working_line is None:
             element = self.code[self.addr.line]

--- a/src/calciumpy/tool/converter.py
+++ b/src/calciumpy/tool/converter.py
@@ -2,8 +2,9 @@ import sys
 import ast
 import json
 import traceback
+import typing
 
-VERSION = "0.4.1"
+VERSION = "0.4.2"
 
 KEYWORD_COMMENT = "#"
 
@@ -173,7 +174,7 @@ class CalciumVisitor(ast.NodeVisitor):
             self.visit(stmt)
 
     def visit_ClassDef(self, node):
-        elems: list[str | None] = [node.name]
+        elems: list[typing.Optional[str]] = [node.name]
         if len(node.bases) > 0:
             elems.append(self.visit(node.bases[0]))
         else:
@@ -323,7 +324,7 @@ class CalciumVisitor(ast.NodeVisitor):
         return node.value
 
     def visit_Attribute(self, node):
-        attrs: list[str | list] = [node.attr]
+        attrs: list[typing.Union[str, list]] = [node.attr]
         childnode = node.value
         while isinstance(childnode, ast.Attribute):
             attrs.insert(0, childnode.attr)
@@ -358,7 +359,7 @@ class CalciumVisitor(ast.NodeVisitor):
         return self.output_node(node, KEYWORD_EXPR_STMT, [value])
 
     def visit_Call(self, node):
-        elems: list[str | list] = [KEYWORD_CALL]
+        elems: list[typing.Union[str, list]] = [KEYWORD_CALL]
         func_ref, args = self.get_call(node)
         elems.append(func_ref)
         elems.append(args)


### PR DESCRIPTION
- Replace "|" type annotation with `typing.*` to support 3.9.x